### PR TITLE
Remove headers and add back arrows for emergency page sections

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,19 +1,23 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
-import { SplashScreen, Stack } from 'expo-router';
-import { useEffect } from 'react';
-import { useColorScheme } from 'react-native';
-import EmergencyContactContextProvider from '../context/contactContext';
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { SplashScreen, Stack } from "expo-router";
+import { useEffect } from "react";
+import { useColorScheme } from "react-native";
+import EmergencyContactContextProvider from "../context/contactContext";
 
 export {
   // Catch any errors thrown by the Layout component.
   ErrorBoundary,
-} from 'expo-router';
+} from "expo-router";
 
 export const unstable_settings = {
   // Ensure that reloading on `/modal` keeps a back button present.
-  initialRouteName: 'index',
+  initialRouteName: "index",
 };
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
@@ -21,7 +25,7 @@ SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   const [loaded, error] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
     ...FontAwesome.font,
   });
 
@@ -48,8 +52,8 @@ function RootLayoutNav() {
 
   return (
     <EmergencyContactContextProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <Stack screenOptions={{ headerShown: false }}>
           {/* <Stack.Screen name="(tabs)" options={{ headerShown: false }} /> */}
           {/* <Stack.Screen name="modal" options={{ presentation: 'modal' }} /> */}
         </Stack>

--- a/app/emergency/contactsPage.tsx
+++ b/app/emergency/contactsPage.tsx
@@ -1,8 +1,11 @@
 import * as Contacts from "expo-contacts";
+import { Link } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
+  Image,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -109,12 +112,22 @@ export default function ContactsPage() {
 
   return (
     <ScrollView style={styles.container}>
-      <Text style={styles.title}>Contacts</Text>
       {isLoading && (
         <View style={styles.overlay}>
           <ActivityIndicator size="large" color="#683d7d" />
         </View>
       )}
+      <View style={styles.header}>
+        <Link href="/emergency" asChild>
+          <Pressable>
+            <Image
+              source={require("../../assets/images/Back.png")}
+              style={styles.backimage}
+            />
+          </Pressable>
+        </Link>
+        <Text style={styles.title}>Contacts</Text>
+      </View>
       {contactList.map((contact, index) => (
         <ContactItem
           name={contact.name}
@@ -131,12 +144,8 @@ const styles = StyleSheet.create({
   container: {
     margin: 5,
     gap: 3,
+    marginTop: -5,
     marginBottom: 35,
-  },
-  title: {
-    fontSize: 20,
-    marginBottom: 10,
-    color: "#683d7d",
   },
   loading: {
     fontSize: 20,
@@ -151,5 +160,24 @@ const styles = StyleSheet.create({
     transitionProperty: "opacity, visibility",
     transitionDuration: "0.75s",
     zIndex: 1,
+  },
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    width: "95%",
+    marginTop: "20%",
+    marginBottom: "10%",
+  },
+  backimage: {
+    height: 30,
+    width: 30,
+    marginRight: "-10%",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginLeft: "auto",
+    marginRight: "auto",
   },
 });

--- a/app/emergency/index.tsx
+++ b/app/emergency/index.tsx
@@ -28,6 +28,17 @@ export default function Emergency() {
 
   return (
     <View style={styles.container}>
+      <View style={styles.header}>
+        <Link href="/homepage" asChild>
+          <Pressable>
+            <Image
+              source={require("../../assets/images/Back.png")}
+              style={styles.backimage}
+            />
+          </Pressable>
+        </Link>
+        <Text style={styles.title}>Emergency</Text>
+      </View>
       {isLoading && (
         <View style={styles.overlay}>
           <ActivityIndicator size="large" color="#683d7d" />
@@ -70,7 +81,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "flex-start",
-    paddingTop: "20%",
+    //paddingTop: "20%",
     alignItems: "center",
     gap: 25,
   },
@@ -112,5 +123,24 @@ const styles = StyleSheet.create({
     transitionProperty: "opacity, visibility",
     transitionDuration: "0.75s",
     zIndex: 1,
+  },
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    width: "95%",
+    marginTop: "20%",
+    marginBottom: "10%",
+  },
+  backimage: {
+    height: 30,
+    width: 30,
+    marginRight: "-10%",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginLeft: "auto",
+    marginRight: "auto",
   },
 });

--- a/app/homepage/_layout.tsx
+++ b/app/homepage/_layout.tsx
@@ -1,16 +1,16 @@
-import { Pressable, StyleSheet, useColorScheme, Image } from 'react-native';
-import { Link, Tabs, Stack } from 'expo-router';
-import { Text, View } from '../../components/Themed';
-import { FontAwesome } from '@expo/vector-icons';
-import Colors from '../../constants/Colors';
-import { DarkTheme, DefaultTheme, NavigationContainer, StackActions, ThemeProvider } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { Stack } from "expo-router";
+import { useColorScheme } from "react-native";
 
 export default function HomePageLayout() {
   const colorScheme = useColorScheme();
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-      </Stack>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+      <Stack screenOptions={{ headerShown: false }}></Stack>
     </ThemeProvider>
-  )
+  );
 }


### PR DESCRIPTION
Remove default headers for all pages from both layout files and added back arrow and page title for emergency page sections, also added adjusted styling from removing headers. 